### PR TITLE
Delete tabs from current window on exceeding max tab limit

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,10 @@
 const MAX_TABS = 10;
 
 chrome.tabs.onCreated.addListener(async () => {
-  const tabs = await chrome.tabs.query({});
+  const tabs = await chrome.tabs.query({
+    // Gets all the tabs from the current window.
+    currentWindow: true,
+  });
   if (tabs.length > MAX_TABS) {
     const sortedTabs = tabs.sort((a, b) => b.id - a.id);
     const tabsToClose = sortedTabs.slice(MAX_TABS);


### PR DESCRIPTION
Gets the list of Tabs opened on the current window and delete the oldest one when the Tab limit exceeds.

This will allow the user to limit the number of tabs opened on their current window. Their other opened chrome window tabs remains un-impacted.